### PR TITLE
fix: resolve hydration error by replacing nested p tags with span

### DIFF
--- a/content/docs/components.mdx
+++ b/content/docs/components.mdx
@@ -67,9 +67,9 @@ Here's an example of tabs in action:
           <div className="flex items-center space-y-2">
             <div>
               <h4 className="font-medium">Example Component</h4>
-              <p className="text-sm text-muted-foreground">
+              <span className="text-sm text-muted-foreground">
                 This is a preview of a React component
-              </p>
+              </span>
             </div>
           </div>
 
@@ -88,9 +88,9 @@ Here's an example of tabs in action:
         <div className="flex items-center space-y-2">
           <div>
             <h4 className="font-medium">Example Component</h4>
-            <p className="text-sm text-muted-foreground">
+            <span className="text-sm text-muted-foreground">
               This is a preview of a React component
-            </p>
+            </span>
           </div>
         </div>
 


### PR DESCRIPTION
# Title
fix: resolve hydration error from nested paragraph tags #1

## Description
Fixes a hydration error in Components.mdx by replacing nested `<p>` tags with `<span>` tags to maintain valid HTML structure while preserving styling.

Closes #[issue-number]

## Changes
- Replace nested `<p>` tag with `<span>` in components.mdx tabs example
- Maintains existing styling and functionality
- Resolves React hydration mismatch warning

## Testing
- Verified hydration error is resolved
- Confirmed styling remains consistent
- Tested component rendering in development environment